### PR TITLE
Makes sure minimum version of Vagrant is being used

### DIFF
--- a/vagrantfile-windows_10.template
+++ b/vagrantfile-windows_10.template
@@ -1,6 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+Vagrant.require_version ">= 1.8.0"
+
 # By default this VM will use 2 processor cores and 2GB of RAM. The 'VM_CPUS' and
 # "VM_RAM" environment variables can be used to change that behaviour.
 cpus = ENV["VM_CPUS"] || 2


### PR DESCRIPTION
Vagrant 1.8.0 or newer is required for WinRM to work reliably.
