### PR TITLE
Updated guest_os_type to Windows10_64

### DIFF
--- a/windows_10.json
+++ b/windows_10.json
@@ -11,7 +11,7 @@
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "2h",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
-      "guest_os_type": "Windows81_64",
+      "guest_os_type": "Windows10_64",
       "disk_size": 61440,
       "floppy_files": [
         "{{user `autounattend`}}",


### PR DESCRIPTION
I guess that this needs to be updated according to the version of Windows we're using right now.
