### PR TITLE
Brings in the latest update changes

### DIFF
--- a/scripts/chocolatey-packages.bat
+++ b/scripts/chocolatey-packages.bat
@@ -12,3 +12,4 @@ set choco_binary=c:\programdata\chocolatey\bin\choco.exe
 %choco_binary% install microsoft-build-tools -y
 %choco_binary% install visualcppbuildtools -y
 setx /M VCTargetsPath "C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
+

--- a/scripts/chocolatey-packages.bat
+++ b/scripts/chocolatey-packages.bat
@@ -1,5 +1,7 @@
 set choco_binary=c:\programdata\chocolatey\bin\choco.exe
 
+%choco_binary% feature enable -n allowEmptyChecksums
+
 %choco_binary% install sysinternals -y
 %choco_binary% install curl -y
 %choco_binary% install jre8 -y
@@ -10,4 +12,3 @@ set choco_binary=c:\programdata\chocolatey\bin\choco.exe
 %choco_binary% install microsoft-build-tools -y
 %choco_binary% install visualcppbuildtools -y
 setx /M VCTargetsPath "C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140"
-

--- a/vagrantfile-windows_10.template
+++ b/vagrantfile-windows_10.template
@@ -8,8 +8,6 @@ Vagrant.require_version ">= 1.8.0"
 cpus = ENV["VM_CPUS"] || 2
 ram = ENV["VM_RAM"] || 2048
 
-Vagrant.require_version ">= 1.6.2"
-
 Vagrant.configure("2") do |config|
     config.vm.box = "inclusivedesign/windows10-eval"
     config.vm.define "windows10-eval"
@@ -28,8 +26,8 @@ Vagrant.configure("2") do |config|
         v.gui = true
         v.customize ["modifyvm", :id, "--memory", ram]
         v.customize ["modifyvm", :id, "--cpus", cpus]
-        v.customize ["modifyvm", :id, "--vram", "128"]
-        v.customize ["modifyvm", :id, "--accelerate3d", "on"]
+        v.customize ["modifyvm", :id, "--vram", "256"]
+        v.customize ["modifyvm", :id, "--accelerate3d", "off"]
         v.customize ["modifyvm", :id, "--audio", "null", "--audiocontroller", "hda"]
         v.customize ["modifyvm", :id, "--ioapic", "on"]
         v.customize ["setextradata", "global", "GUI/SuppressMessages", "all" ]

--- a/windows_10.json
+++ b/windows_10.json
@@ -63,9 +63,9 @@
     }
   ],
   "variables": {
-    "iso_url": "http://care.dlservice.microsoft.com/dl/download/C/3/9/C399EEA8-135D-4207-92C9-6AAB3259F6EF/10240.16384.150709-1700.TH1_CLIENTENTERPRISEEVAL_OEMRET_X64FRE_EN-US.ISO",
+    "iso_url": "http://care.dlservice.microsoft.com/dl/download/2/5/4/254230E8-AEA5-43C5-94F6-88CE222A5846/14393.0.160715-1616.RS1_RELEASE_CLIENTENTERPRISEEVAL_OEMRET_X64FRE_EN-US.ISO",
     "iso_checksum_type": "sha1",
-    "iso_checksum": "56ab095075be28a90bc0b510835280975c6bb2ce",
+    "iso_checksum": "a86ae3d664553cd0ee9a6bcd83a5dbe92e3dc41a",
     "autounattend": "./upstream/answer_files/10/Autounattend.xml"
   }
 }


### PR DESCRIPTION
As discussed we need to disable Chocolatey 0.10.0's new behaviour of erroring out when downloading packages from non-HTTPS URLs. This PR also includes changes required to update Windows 10 to the ver 1607 build.
