### PR TITLE
GPII-2071 - Disable Windows Defender

### DIFF
--- a/scripts/disable-windows-defender.ps1
+++ b/scripts/disable-windows-defender.ps1
@@ -1,0 +1,3 @@
+Set-MpPreference -DisableRealtimeMonitoring $true
+New-ItemProperty -Path 'hklm:\SOFTWARE\Policies\Microsoft\Windows Defender' -Name "DisableAntiSpyware" -Value 1 -PropertyType "DWORD"
+New-ItemProperty -Path 'hklm:\SOFTWARE\Policies\Microsoft\Windows Defender' -Name "DisableRoutinelyTakingAction" -Value 1 -PropertyType "DWORD"

--- a/windows_10.json
+++ b/windows_10.json
@@ -41,6 +41,13 @@
     }
   ],
   "provisioners": [
+	{
+      "type": "powershell",
+      "execute_command": "powershell '& { {{.Path}}; exit $LastExitCode }'",
+      "scripts": [
+        "./scripts/disable-windows-defender.ps1"
+      ]
+    },
     {
       "type": "file",
       "source": "doit",


### PR DESCRIPTION
The two registry entries disable Windows Defender active scan and set a
group policy that avoids a possible unexpected reactivation during a
future Windows update.

More info: http://superuser.com/a/1007521/151580

This PR closes https://issues.gpii.net/browse/GPII-2064
