### PR TITLE
Revert "Update to 1803 release"

### DIFF
--- a/windows_10_x64.json
+++ b/windows_10_x64.json
@@ -102,9 +102,9 @@
     }
   ],
   "variables": {
-    "iso_url": "http://software-download.microsoft.com/download/pr/17134.1.180410-1804.rs4_release_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
+    "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/5/D/65D18931-F626-4A35-AD5B-F5DA41FE6B76/16299.15.170928-1534.rs3_release_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
     "iso_checksum_type": "sha1",
-    "iso_checksum": "a4ea45ec1282e85fc84af49acf7a8d649c31ac5c",
+    "iso_checksum": "3b5f9494d870726d6d8a833aaf6169a964b8a9be",
     "autounattend": "./answer_files/10_64/Autounattend.xml",
     "vm_product": "windows10-eval-x64",
     "vm_description": "Windows 10 Evaluation version for testing"

--- a/windows_10_x64_apps.json
+++ b/windows_10_x64_apps.json
@@ -114,9 +114,9 @@
     }
   ],
   "variables": {
-    "iso_url": "http://software-download.microsoft.com/download/pr/17134.1.180410-1804.rs4_release_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
+    "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/5/D/65D18931-F626-4A35-AD5B-F5DA41FE6B76/16299.15.170928-1534.rs3_release_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
     "iso_checksum_type": "sha1",
-    "iso_checksum": "a4ea45ec1282e85fc84af49acf7a8d649c31ac5c",
+    "iso_checksum": "3b5f9494d870726d6d8a833aaf6169a964b8a9be",
     "autounattend": "./answer_files/10_64/Autounattend.xml",
     "vm_product": "windows10-eval-x64-Apps",
     "vm_description": "Windows 10 Evaluation version for testing"

--- a/windows_10_x86.json
+++ b/windows_10_x86.json
@@ -102,9 +102,9 @@
     }
   ],
   "variables": {
-    "iso_url": "http://software-download.microsoft.com/download/pr/17134.1.180410-1804.rs4_release_CLIENTENTERPRISEEVAL_OEMRET_x86FRE_en-us.iso",
+    "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/5/D/65D18931-F626-4A35-AD5B-F5DA41FE6B76/16299.15.170928-1534.rs3_release_CLIENTENTERPRISEEVAL_OEMRET_x86FRE_en-us.iso",
     "iso_checksum_type": "sha1",
-    "iso_checksum": "ddb496534203cb98284e5484e0ad60af3c0efce7",
+    "iso_checksum": "4a75747a47eb689497fe57d64cec375c7949aa97",
     "autounattend": "./answer_files/10_32/Autounattend.xml",
     "vm_product": "windows10-eval-x86",
     "vm_description": "Windows 10 Evaluation version for testing"

--- a/windows_10_x86_apps.json
+++ b/windows_10_x86_apps.json
@@ -114,9 +114,9 @@
     }
   ],
   "variables": {
-    "iso_url": "http://software-download.microsoft.com/download/pr/17134.1.180410-1804.rs4_release_CLIENTENTERPRISEEVAL_OEMRET_x86FRE_en-us.iso",
+    "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/5/D/65D18931-F626-4A35-AD5B-F5DA41FE6B76/16299.15.170928-1534.rs3_release_CLIENTENTERPRISEEVAL_OEMRET_x86FRE_en-us.iso",
     "iso_checksum_type": "sha1",
-    "iso_checksum": "ddb496534203cb98284e5484e0ad60af3c0efce7",
+    "iso_checksum": "4a75747a47eb689497fe57d64cec375c7949aa97",
     "autounattend": "./answer_files/10_32/Autounattend.xml",
     "vm_product": "windows10-eval-x86-Apps",
     "vm_description": "Windows 10 Evaluation version for testing"


### PR DESCRIPTION
This reverts commit 0eecaf343162c204017356cf6baaaa92bc98a5ae.

The latest version 1803 of Windows 10 seems to have some issues passing the tests GPII-3084

This PR undoes the changes to build the 1803 version